### PR TITLE
Fix date format string

### DIFF
--- a/Source/Clima/MeadowClimaHackKit/Connectivity/MapleRequestHandler.cs
+++ b/Source/Clima/MeadowClimaHackKit/Connectivity/MapleRequestHandler.cs
@@ -25,7 +25,7 @@ namespace MeadowClimaHackKit.Connectivity
                 data.Add(new TemperatureModel()
                 {
                     Temperature = log.TemperatureCelcius?.ToString("00"),
-                    DateTime = log.DateTime.ToString("yyyy-mm-dd hh:mm:ss tt")
+                    DateTime = log.DateTime.ToString("yyyy-MM-dd hh:mm:ss tt"),
                 });
             }
 


### PR DESCRIPTION
Date format is specifies "mm" which is minutes. Should be "MM" for month.