### PR TITLE
Return max 100 for Get All and add paged response

### DIFF
--- a/Source/Clima/MeadowClimaHackKit/Connectivity/MapleRequestHandler.cs
+++ b/Source/Clima/MeadowClimaHackKit/Connectivity/MapleRequestHandler.cs
@@ -10,6 +10,9 @@ namespace MeadowClimaHackKit.Connectivity
 {
     public class MapleRequestHandler : RequestHandlerBase
     {
+
+        private const int MAX_PAGE_SIZE = 50;
+
         public MapleRequestHandler() { }
 
         [HttpGet("/gettemperaturelogs")]
@@ -17,8 +20,28 @@ namespace MeadowClimaHackKit.Connectivity
         {
             LedController.Instance.SetColor(Color.Magenta);
 
-            var logs = DatabaseManager.Instance.GetTemperatureReadings();
+            var logs = DatabaseManager.Instance.GetAllTemperatureReadings();
+            var data = MapDtoTemperatureModels(logs);
 
+            LedController.Instance.SetColor(Color.Green);
+            return new JsonResult(data);
+        }
+
+        [HttpGet("/gettemperaturepage/{page}")]
+        public IActionResult GetTemperaturePage(int page)
+        {
+            LedController.Instance.SetColor(Color.Magenta);
+
+            var logs = DatabaseManager.Instance.GetTemperatureReadings(MAX_PAGE_SIZE, page);
+
+            var data = MapDtoTemperatureModels(logs);
+
+            LedController.Instance.SetColor(Color.Green);
+            return new JsonResult(data);
+        }
+
+        private static List<TemperatureModel> MapDtoTemperatureModels(List<TemperatureTable> logs)
+        {
             var data = new List<TemperatureModel>();
             foreach (var log in logs)
             {
@@ -29,8 +52,7 @@ namespace MeadowClimaHackKit.Connectivity
                 });
             }
 
-            LedController.Instance.SetColor(Color.Green);
-            return new JsonResult(data);
+            return data;
         }
     }
 }

--- a/Source/Clima/MeadowClimaHackKit/Database/DatabaseManager.cs
+++ b/Source/Clima/MeadowClimaHackKit/Database/DatabaseManager.cs
@@ -10,6 +10,8 @@ namespace MeadowClimaHackKit.Database
 {
     public class DatabaseManager
     {
+        private const int MAX_PAGE_SIZE = 100;
+
         private static readonly Lazy<DatabaseManager> instance =
             new Lazy<DatabaseManager>(() => new DatabaseManager());
         public static DatabaseManager Instance => instance.Value;
@@ -25,12 +27,36 @@ namespace MeadowClimaHackKit.Database
 
         protected void Initialize()
         {
+            //DeleteDatabaseFile("ClimateReadings.db");
+
             var databasePath = Path.Combine(MeadowOS.FileSystem.DataDirectory, "ClimateReadings.db");
+            var isNewDatabase = !File.Exists(databasePath);
+
             Database = new SQLiteConnection(databasePath);
 
-            Database.DropTable<TemperatureTable>(); //convenience while we work on the model object
-            Database.CreateTable<TemperatureTable>();
+            if (isNewDatabase)
+            {
+                // Create the tables we need
+                Console.WriteLine("DatabaseManager: Create the tables we need");
+                Database.DropTable<TemperatureTable>(); //convenience while we work on the model object
+                Database.CreateTable<TemperatureTable>();
+            }
+
             isConfigured = true;
+        }
+
+        protected void DeleteDatabaseFile(string fileName)
+        {
+            string dbFile = Path.Combine(MeadowOS.FileSystem.DataDirectory, fileName);
+            if (File.Exists(dbFile))
+            {
+                File.Delete(dbFile);
+            }
+            dbFile += "-journal";
+            if (File.Exists(dbFile))
+            {
+                File.Delete(dbFile);
+            }
         }
 
         public bool SaveReading(TemperatureTable temperature)
@@ -39,25 +65,64 @@ namespace MeadowClimaHackKit.Database
 
             if (isConfigured == false)
             {
-                Console.WriteLine("SaveUpdateReading: DB not ready");
+                Console.WriteLine("SaveReading: DB not ready");
                 return false;
             }
 
             if (temperature == null)
             {
-                Console.WriteLine("SaveUpdateReading: Conditions is null");
+                Console.WriteLine("SaveReading: Conditions is null");
                 return false;
             }
+            Console.WriteLine("SaveReading: Saving temperature reading to DB");
 
             Database.Insert(temperature);
 
+            Console.WriteLine("SaveReading: Successfully saved to database");
+            Console.WriteLine($"SaveReading: Count={GetCountReadings()} GetTotalMemory={GC.GetTotalMemory(true)}");
             LedController.Instance.SetColor(Color.Green);
             return true;
         }
 
-        public List<TemperatureTable> GetTemperatureReadings()
+        public List<TemperatureTable> GetAllTemperatureReadings()
         {
+            int TotalCount = GetCountReadings();
+            Console.WriteLine($"GetAllReadings:  TotalCount={TotalCount} ...");
+            if (TotalCount > MAX_PAGE_SIZE)
+            {
+                return GetTemperatureReadings(MAX_PAGE_SIZE, 1); // return latest 100 readings to avoid memory overflow
+            }
             return Database.Table<TemperatureTable>().ToList();
+        }
+        public List<TemperatureTable> GetTemperatureReadings(int pageSize, int pageNumber = 1)
+        {
+            int TotalCount = GetCountReadings();
+            int PageSize = pageSize <= MAX_PAGE_SIZE ? pageSize : MAX_PAGE_SIZE; 
+            int TotalPages = (int)Math.Ceiling(TotalCount / (double)pageSize);
+
+            if (pageNumber <= 0)
+            {
+                pageNumber = 1;
+            }
+            if (pageNumber > TotalPages)
+            {
+                pageNumber = TotalPages;
+            }
+            int CurrentPage = pageNumber;
+
+            Console.WriteLine($"GetReadings:  TotalCount={TotalCount} TotalPages={TotalPages} PageSize={PageSize} CurrentPage={CurrentPage} ");
+            if (TotalCount < PageSize)
+            {
+                return Database.Table<TemperatureTable>().ToList();
+            }
+            //var items = Database.Table<TemperatureTable>().Take(pageSize).OrderByDescending(t => t.ID).ToList();
+            //var items = Database.Table<TemperatureTable>().Skip(TotalCount - (CurrentPage * pageSize)).Take(pageSize).OrderByDescending(t => t.ID)..ToList();
+            var items = Database.Table<TemperatureTable>().Skip((CurrentPage - 1) * pageSize).Take(pageSize).OrderByDescending(t => t.ID).ToList();
+            return items;
+        }
+        public int GetCountReadings()
+        {
+            return Database.Table<TemperatureTable>().Count();
         }
     }
 }


### PR DESCRIPTION
A long running Clima app will have many thousands of records. Trying to return them all in response to HTTP GET is not practical and will exhaust resources. 

This change limits the number of rows that can be returned in one HTTP GET to 100. It adds a second HTTP endpoint that returns data in pages of 50 records. Arbitrarily chosen limits. Need to experiment on what are reasonable limits. Ideally in the future the web API would include headers to aid paging. Current Maple only supports a single URL parameter which is being used here to select the page. 

URL for paged access is : http://192.168.2.112:5417/gettemperaturepage/1

Note records are returned with the most recent record first on page 1. 
