### PR TITLE
Read battery voltage and clean up logged text  and comments

### DIFF
--- a/Source/Clima_Demo/MeadowApp.cs
+++ b/Source/Clima_Demo/MeadowApp.cs
@@ -20,6 +20,7 @@ namespace Clima_Demo
             Resolver.Log.Info("Initialize hardware...");
 
             clima = Clima.Create();
+            clima.ColorLed.SetColor(Color.Red);
 
             Resolver.Log.Info($"Running on Clima Hardware {clima.RevisionString}");
 
@@ -51,6 +52,11 @@ namespace Clima_Demo
             if (clima.SolarVoltageInput is { } solarVoltage)
             {
                 solarVoltage.Updated += SolarVoltageUpdated;
+            }
+
+            if (clima.BatteryVoltageInput is { } batteryVoltage)
+            {
+               batteryVoltage.Updated += BatteryVoltageUpdated;
             }
 
             if (clima.Gnss is { } gnss)
@@ -142,6 +148,11 @@ namespace Clima_Demo
                 solarVoltage.StartUpdating(updateInterval);
             }
 
+            if (clima.BatteryVoltageInput is { } batteryVoltage)
+            {
+                batteryVoltage.StartUpdating(updateInterval);
+            }
+
             if (clima.Gnss is { } gnss)
             {
                 gnss.StartUpdating();
@@ -158,6 +169,11 @@ namespace Clima_Demo
         private void SolarVoltageUpdated(object sender, IChangeResult<Voltage> e)
         {
             Resolver.Log.Info($"Solar Voltage: {e.New.Volts:0.#} volts");
+        }
+
+        private void BatteryVoltageUpdated(object sender, IChangeResult<Voltage> e)
+        {
+            Resolver.Log.Info($"Battery Voltage: {e.New.Volts:0.#} volts");
         }
 
         private void AnemometerUpdated(object sender, IChangeResult<Speed> e)

--- a/Source/Meadow.Clima/ClimaHardwareV2.cs
+++ b/Source/Meadow.Clima/ClimaHardwareV2.cs
@@ -49,6 +49,11 @@ namespace Meadow.Devices
         public IAnalogInputPort? SolarVoltageInput { get; protected set; }
 
         /// <summary>
+        /// The Solar Voltage Input on the Clima board
+        /// </summary>
+        public IAnalogInputPort? BatteryVoltageInput { get; protected set; }
+
+        /// <summary>
         /// Gets the RGB PWM LED
         /// </summary>
         public RgbPwmLed? ColorLed { get; set; }
@@ -81,7 +86,7 @@ namespace Meadow.Devices
             {
                 Logger?.Trace("Instantiating atmospheric sensor");
                 AtmosphericSensor = new Bme688(I2cBus, (byte)Bme688.Addresses.Address_0x76);
-                Logger?.Trace("Environmental sensor up");
+                Logger?.Trace("Atmospheric sensor up");
             }
             catch (Exception ex)
             {
@@ -90,9 +95,9 @@ namespace Meadow.Devices
 
             try
             {
-                Resolver.Log.Debug("Initializing GNSS");
+                Resolver.Log?.Trace("Initializing GNSS");
                 Gnss = new NeoM8(device, device.PlatformOS.GetSerialPortName("COM4"), null, null);
-                Resolver.Log.Debug("GNSS initialized");
+                Resolver.Log?.Trace("GNSS initialized");
             }
             catch (Exception e)
             {
@@ -107,7 +112,7 @@ namespace Meadow.Devices
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Unabled to create the Wind Vane: {ex.Message}");
+                Resolver.Log.Error($"Unable to create the Wind Vane: {ex.Message}");
             }
 
             try
@@ -118,7 +123,7 @@ namespace Meadow.Devices
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Unabled to create the Switching Rain Gauge: {ex.Message}");
+                Resolver.Log.Error($"Unable to create the Switching Rain Gauge: {ex.Message}");
             }
 
             try
@@ -129,7 +134,7 @@ namespace Meadow.Devices
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Unabled to create the Switching Anemometer: {ex.Message}");
+                Resolver.Log.Error($"Unable to create the Switching Anemometer: {ex.Message}");
             }
 
             try
@@ -140,7 +145,7 @@ namespace Meadow.Devices
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Unabled to create the Switching Anemometer: {ex.Message}");
+                Resolver.Log.Error($"Unable to create the Solar Voltage Input: {ex.Message}");
             }
 
             try
@@ -151,7 +156,7 @@ namespace Meadow.Devices
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Unabled to create the RGB LED: {ex.Message}");
+                Resolver.Log.Error($"Unable to create the RGB LED: {ex.Message}");
             }
         }
     }

--- a/Source/Meadow.Clima/ClimaHardwareV3.cs
+++ b/Source/Meadow.Clima/ClimaHardwareV3.cs
@@ -15,17 +15,17 @@ namespace Meadow.Devices
     public class ClimaHardwareV3 : IClimaHardware
     {
         /// <summary>
-        /// Gets the I2C Bus
+        /// The I2C Bus
         /// </summary>
         public II2cBus I2cBus { get; protected set; }
 
         /// <summary>
-        /// Gets the BME688 environmental sensor on the Clima board
+        /// The BME688 atmospheric sensor on the Clima board
         /// </summary>
         public Bme688? AtmosphericSensor { get; protected set; }
 
         /// <summary>
-        /// The BME688 environmental sensor on the Clima board
+        /// The SCD40 environmental sensor on the Clima board
         /// </summary>
         public Scd40? EnvironmentalSensor { get; protected set; }
 
@@ -48,6 +48,11 @@ namespace Meadow.Devices
         /// The Solar Voltage Input on the Clima board
         /// </summary>
         public IAnalogInputPort? SolarVoltageInput { get; protected set; }
+
+        /// <summary>
+        /// The Solar Voltage Input on the Clima board
+        /// </summary>
+        public IAnalogInputPort? BatteryVoltageInput { get; protected set; }
 
         /// <summary>
         /// Gets the RGB PWM LED
@@ -135,7 +140,7 @@ namespace Meadow.Devices
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Unabled to create the Wind Vane: {ex.Message}");
+                Resolver.Log.Error($"Unable to create the Wind Vane: {ex.Message}");
             }
 
             try
@@ -146,7 +151,7 @@ namespace Meadow.Devices
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Unabled to create the Switching Rain Gauge: {ex.Message}");
+                Resolver.Log.Error($"Unable to create the Switching Rain Gauge: {ex.Message}");
             }
 
             try
@@ -157,7 +162,7 @@ namespace Meadow.Devices
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Unabled to create the Switching Anemometer: {ex.Message}");
+                Resolver.Log.Error($"Unable to create the Switching Anemometer: {ex.Message}");
             }
 
             try
@@ -165,10 +170,31 @@ namespace Meadow.Devices
                 Logger?.Trace("Instantiating Solar Voltage Input");
                 SolarVoltageInput = device.Pins.A02.CreateAnalogInputPort(5);
                 Logger?.Trace("Solar Voltage Input up");
+
+                //SolarVoltageInput.Updated += (s, result) => {
+                //    Logger?.Trace($"Analog event, new Solar   voltage: {result.New.Volts:N2}V, old: {result.Old?.Volts:N2}V");
+                //};
+                //SolarVoltageInput.StartUpdating();
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Unabled to create the Switching Anemometer: {ex.Message}");
+                Resolver.Log.Error($"Unable to create the Solar Voltage Input: {ex.Message}");
+            }
+
+            try
+            {
+                Logger?.Trace("Instantiating Battery Voltage Input");
+                BatteryVoltageInput = device.Pins.A04.CreateAnalogInputPort(5);
+                Logger?.Trace("Battery Voltage Input up");
+
+                //BatteryVoltageInput.Updated += (s, result) => {
+                //    Logger?.Trace($"Analog event, new battery voltage: {result.New.Volts:N2}V, old: {result.Old?.Volts:N2}V");
+                //};
+                //BatteryVoltageInput.StartUpdating();
+            }
+            catch (Exception ex)
+            {
+                Resolver.Log.Error($"Unable to create the Battery Voltage Input: {ex.Message}");
             }
 
             try
@@ -179,7 +205,7 @@ namespace Meadow.Devices
             }
             catch (Exception ex)
             {
-                Resolver.Log.Error($"Unabled to create the RGB LED: {ex.Message}");
+                Resolver.Log.Error($"Unable to create the RGB LED: {ex.Message}");
             }
         }
     }

--- a/Source/Meadow.Clima/IClimaHardware.cs
+++ b/Source/Meadow.Clima/IClimaHardware.cs
@@ -52,6 +52,11 @@ namespace Meadow.Devices
         public IAnalogInputPort? SolarVoltageInput { get; }
 
         /// <summary>
+        /// The Battery Voltage Input on the Clima board
+        /// </summary>
+        public IAnalogInputPort? BatteryVoltageInput { get; }
+
+        /// <summary>
         /// Gets the RGB PWM LED
         /// </summary>
         public RgbPwmLed? ColorLed { get; }


### PR DESCRIPTION
On Clima V3 hardware, the battery is connected to an analogue input through a voltage divider. Copy the existing code that reads solar voltage and adjust to read and output the battery voltage on V3 Clima. 

Fix typos in Log text. 

Set V2 & V3 interface comments to have the same text.