### PR TITLE
Add using Meadow to reference the correct Color class

### DIFF
--- a/Source/Additional Samples/Clima_HackKit_Demo/Connectivity/BluetoothServer.cs
+++ b/Source/Additional Samples/Clima_HackKit_Demo/Connectivity/BluetoothServer.cs
@@ -2,6 +2,7 @@
 using Meadow.Gateways.Bluetooth;
 using Clima_HackKit_Demo.Controller;
 using System;
+using Meadow;
 using Meadow.Foundation;
 
 namespace Clima_HackKit_Demo.Connectivity

--- a/Source/Additional Samples/Clima_HackKit_Demo/Connectivity/MapleRequestHandler.cs
+++ b/Source/Additional Samples/Clima_HackKit_Demo/Connectivity/MapleRequestHandler.cs
@@ -5,6 +5,7 @@ using Meadow.Foundation.Web.Maple.Routing;
 using Clima_HackKit_Demo.Controller;
 using Clima_HackKit_Demo.Database;
 using System.Collections.Generic;
+using Meadow;
 
 namespace Clima_HackKit_Demo.Connectivity
 {

--- a/Source/Additional Samples/Clima_HackKit_Demo/Controller/DisplayController.cs
+++ b/Source/Additional Samples/Clima_HackKit_Demo/Controller/DisplayController.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Meadow;
 
 namespace Clima_HackKit_Demo.Controller
 {

--- a/Source/Additional Samples/Clima_HackKit_Demo/Controller/LedController.cs
+++ b/Source/Additional Samples/Clima_HackKit_Demo/Controller/LedController.cs
@@ -1,6 +1,7 @@
 ﻿using Meadow.Foundation;
 using Meadow.Foundation.Leds;
 using System;
+using Meadow;
 
 namespace Clima_HackKit_Demo.Controller
 {


### PR DESCRIPTION
Changes in Meadow assemblies required adding using Meadow to Clima projects to permit build to succeed where Color class referenced. 