### PR TITLE
Improve connecting to WIFI, add UdpLogging, OTA Restart Command and Updates

### DIFF
--- a/Source/Clima_Demo/Commands/RestartCommand.cs
+++ b/Source/Clima_Demo/Commands/RestartCommand.cs
@@ -1,0 +1,30 @@
+﻿using Meadow;
+using Meadow.Cloud;
+using System.Threading;
+
+namespace Clima_Demo.Commands;
+
+/// <summary>
+/// Restart Clima
+/// </summary>
+public class RestartCommand : IMeadowCommand
+{
+    /// <summary>
+    /// Delay to restart
+    /// </summary>
+    public int Delay { get; set; }
+
+    /// <summary>
+    /// Initialise the command and register handler.
+    /// </summary>
+    public static void Initialise()
+    {
+        Resolver.CommandService.Subscribe<RestartCommand>(command =>
+        {
+            Resolver.Log.Info($"RestartCommand: Meadow will restart in {command.Delay} seconds.");
+            Thread.Sleep(command.Delay * 1000);
+            Resolver.Device.PlatformOS.Reset();
+        });
+
+    }
+}

--- a/Source/Clima_Demo/MeadowApp.cs
+++ b/Source/Clima_Demo/MeadowApp.cs
@@ -71,6 +71,8 @@ public class ClimaApp : ClimaAppBase
             updateService.ApplyUpdate(info);
         };
 
+        RestartCommand.Initialise();
+
         return Task.CompletedTask;
     }
 

--- a/Source/Clima_Demo/MeadowApp.cs
+++ b/Source/Clima_Demo/MeadowApp.cs
@@ -1,4 +1,5 @@
-﻿using Meadow;
+﻿using Clima_Demo.Commands;
+using Meadow;
 using Meadow.Devices;
 using Meadow.Devices.Esp32.MessagePayloads;
 using Meadow.Hardware;
@@ -27,6 +28,48 @@ public class ClimaApp : ClimaAppBase
 
         var wifi = Hardware.ComputeModule.NetworkAdapters.Primary<IWiFiNetworkAdapter>();
         mainController.Initialize(Hardware, wifi);
+
+        return Task.CompletedTask;
+    }
+
+    public override Task Run()
+    {
+        var svc = Resolver.UpdateService;
+
+        // Uncomment to clear any persisted update info. This allows installing 
+        // the same update multiple times, such as you might do during development.
+        // svc.ClearUpdates();
+
+        svc.StateChanged += (sender, updateState) =>
+        {
+            Resolver.Log.Info($"UpdateState {updateState}");
+        };
+
+        svc.RetrieveProgress += (updateService, info) =>
+        {
+            short percentage = (short)((double)info.DownloadProgress / info.FileSize * 100);
+
+            Resolver.Log.Info($"Downloading... {percentage}%");
+        };
+
+        svc.UpdateAvailable += async (updateService, info) =>
+        {
+            Resolver.Log.Info($"Update available!");
+
+            // Queue update for retrieval "later"
+            await Task.Delay(5000);
+
+            updateService.RetrieveUpdate(info);
+        };
+
+        svc.UpdateRetrieved += async (updateService, info) =>
+        {
+            Resolver.Log.Info($"Update retrieved!");
+
+            await Task.Delay(5000);
+
+            updateService.ApplyUpdate(info);
+        };
 
         return Task.CompletedTask;
     }

--- a/Source/Clima_Demo/MeadowApp.cs
+++ b/Source/Clima_Demo/MeadowApp.cs
@@ -43,6 +43,10 @@ public class ClimaApp : ClimaAppBase
         svc.StateChanged += (sender, updateState) =>
         {
             Resolver.Log.Info($"UpdateState {updateState}");
+            if (updateState == UpdateState.DownloadingFile)
+            {
+                mainController?.StopUpdating();
+            }
         };
 
         svc.RetrieveProgress += (updateService, info) =>

--- a/Source/Clima_Demo/app.config.yaml
+++ b/Source/Clima_Demo/app.config.yaml
@@ -23,10 +23,10 @@ MeadowCloud:
     Enabled: true
 
     # Enable Over-the-air Updates
-#    EnableUpdates: false
+    EnableUpdates: true
 
     # Enable Health Metrics
     EnableHealthMetrics: true
 
     # How often to send metrics to Meadow.Cloud
-    HealthMetricsIntervalMinutes: 60
+    HealthMetricsIntervalMinutes: 5

--- a/Source/Clima_Demo/meadow.config.yaml
+++ b/Source/Clima_Demo/meadow.config.yaml
@@ -16,7 +16,7 @@ Coprocessor:
 
     # Should the ESP32 automatically attempt to connect to an access point at startup?
     # If set to true, wifi.yaml credentials must be stored in the device.
-    AutomaticallyStartNetwork: true
+    AutomaticallyStartNetwork: false
 
     # Should the ESP32 automatically reconnect to the configured access point?
     AutomaticallyReconnect: true

--- a/Source/Meadow.Clima.sln
+++ b/Source/Meadow.Clima.sln
@@ -42,6 +42,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MQTTnet", "..\..\MQTTnet\So
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serialization.MicroJson", "..\..\Meadow.Foundation\Source\Meadow.Foundation.Libraries_and_Frameworks\Serialization.MicroJson\Driver\Serialization.MicroJson.csproj", "{6300EAB4-806F-4C18-8FE0-57C45A2C0C58}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Meadow.Logging.LogProviders", "..\..\Meadow.Logging\Source\Meadow.Logging.LogProviders\Driver\Meadow.Logging.LogProviders.csproj", "{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -364,6 +366,24 @@ Global
 		{6300EAB4-806F-4C18-8FE0-57C45A2C0C58}.Release|iPhone.Build.0 = Release|Any CPU
 		{6300EAB4-806F-4C18-8FE0-57C45A2C0C58}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{6300EAB4-806F-4C18-8FE0-57C45A2C0C58}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Debug|iPhone.Deploy.0 = Debug|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Debug|iPhoneSimulator.Deploy.0 = Debug|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Release|iPhone.Build.0 = Release|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Release|iPhone.Deploy.0 = Release|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -386,6 +406,7 @@ Global
 		{85DC9E85-3472-418A-8065-5EF99323E6FE} = {2889A476-F914-49E8-9F97-4CC6CA34A901}
 		{F6EB1347-3926-4308-BE20-70AC53BEBF1D} = {2889A476-F914-49E8-9F97-4CC6CA34A901}
 		{6300EAB4-806F-4C18-8FE0-57C45A2C0C58} = {2889A476-F914-49E8-9F97-4CC6CA34A901}
+		{07E3B02A-5D79-4551-A77E-DC445E2A6A6A} = {2889A476-F914-49E8-9F97-4CC6CA34A901}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CA61E123-F783-4CB3-8EB2-099EE930ADD4}

--- a/Source/Meadow.Clima/Controllers/NetworkController.cs
+++ b/Source/Meadow.Clima/Controllers/NetworkController.cs
@@ -1,4 +1,5 @@
 ﻿using Meadow.Hardware;
+using Meadow.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -150,6 +151,9 @@ public class NetworkController
 
     private void OnNetworkConnected(INetworkAdapter sender, NetworkConnectionEventArgs args)
     {
+        Resolver.Log.Info("Add UdpLogger");
+        Resolver.Log.AddProvider(new UdpLogger(/*port = */5100));
+
         if (sender is IWiFiNetworkAdapter wifi)
         {
             _ = ReportWiFiScan(wifi);

--- a/Source/Meadow.Clima/Controllers/NetworkController.cs
+++ b/Source/Meadow.Clima/Controllers/NetworkController.cs
@@ -27,18 +27,18 @@ public class NetworkController
     /// <summary>
     /// Gets a value indicating whether the network is connected.
     /// </summary>
-    public bool IsConnected { get; private set; }
+    public bool IsConnected => networkAdapter.IsConnected;
 
     /// <summary>
     /// Gets the total time the network has been down.
     /// </summary>
-    public TimeSpan DownTime { get; private set; }
+    public TimeSpan DownTime => lastDown == null ? TimeSpan.Zero : DateTime.UtcNow - lastDown.Value;
 
     /// <summary>
     /// Gets the period for triggering network down events.
     /// </summary>
-    public TimeSpan DownEventPeriod { get; private set; }
-
+    public TimeSpan DownEventPeriod { get; } = TimeSpan.FromSeconds(30);
+    
     /// <summary>
     /// Initializes a new instance of the <see cref="NetworkController"/> class.
     /// </summary>

--- a/Source/Meadow.Clima/Controllers/NotificationController.cs
+++ b/Source/Meadow.Clima/Controllers/NotificationController.cs
@@ -81,6 +81,7 @@ public class NotificationController
     /// <param name="status">The system status to set.</param>
     public void SetSystemStatus(SystemStatus status)
     {
+        Resolver.Log.Info($"SetSystemStatus = {status}");
         switch (status)
         {
             case SystemStatus.LowPower:

--- a/Source/Meadow.Clima/Controllers/PowerController.cs
+++ b/Source/Meadow.Clima/Controllers/PowerController.cs
@@ -35,7 +35,7 @@ public class PowerController
     /// <summary>
     /// Gets the interval at which power data is updated.
     /// </summary>
-    public TimeSpan UpdateInterval { get; } = TimeSpan.FromSeconds(5);
+    public TimeSpan UpdateInterval { get; private set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// Gets the voltage level below which a battery warning is issued.
@@ -59,12 +59,35 @@ public class PowerController
     public PowerController(IClimaHardware clima)
     {
         this.clima = clima;
-
-        Initialize();
     }
 
-    private void Initialize()
+    /// <summary>
+    /// Remove event handler and stop updating
+    /// </summary>
+    public void StopUpdating()
     {
+        Resolver.Log.Info($"PowerController: Stop Updating");
+        if (clima.SolarVoltageInput is { } solarVoltage)
+        {
+            solarVoltage.Updated -= SolarVoltageUpdated;
+            solarVoltage.StopUpdating();
+        }
+
+        if (clima.BatteryVoltageInput is { } batteryVoltage)
+        {
+            batteryVoltage.Updated -= BatteryVoltageUpdated;
+            batteryVoltage.StopUpdating();
+        }
+    }
+
+    /// <summary>
+    /// Add event handler and start updating
+    /// </summary>
+    /// <param name="powerControllerUpdateInterval"></param>
+    public void StartUpdating(TimeSpan powerControllerUpdateInterval)
+    {
+        UpdateInterval = powerControllerUpdateInterval;
+
         if (clima.SolarVoltageInput is { } solarVoltage)
         {
             solarVoltage.Updated += SolarVoltageUpdated;

--- a/Source/Meadow.Clima/Controllers/PowerController.cs
+++ b/Source/Meadow.Clima/Controllers/PowerController.cs
@@ -107,13 +107,11 @@ public class PowerController
     /// <returns>A task that represents the asynchronous operation. The task result contains the power data.</returns>
     public Task<PowerData> GetPowerData()
     {
-        var data = new PowerData
+        return Task.FromResult(new PowerData
         {
             BatteryVoltage = clima.BatteryVoltageInput?.Voltage ?? null,
             SolarVoltage = clima.SolarVoltageInput?.Voltage ?? null,
-        };
-
-        return new Task<PowerData>(() => data);
+        });
     }
 
     /// <summary>

--- a/Source/Meadow.Clima/Controllers/SensorController.cs
+++ b/Source/Meadow.Clima/Controllers/SensorController.cs
@@ -197,10 +197,15 @@ public class SensorController
     {
         lock (latestData)
         {
-            latestData.WindSpeed = e.New;
+			// sanity check on windspeed to avoid reporting Infinity
+            if (e.New.KilometersPerHour <= 250)
+            {
+                latestData.WindSpeed = e.New;
+            }
         }
 
         Resolver.Log.InfoIf(LogSensorData, $"Anemometer:      {e.New.MetersPerSecond:0.#} m/s");
+        Resolver.Log.InfoIf(LogSensorData, $"Anemometer:      {e.New.KilometersPerHour:0.#} km/hr");
     }
 
     private void RainGaugeUpdated(object sender, IChangeResult<Length> e)

--- a/Source/Meadow.Clima/MainController.cs
+++ b/Source/Meadow.Clima/MainController.cs
@@ -50,8 +50,11 @@ public class MainController
         Resolver.Log.Info($"Running on Clima Hardware {hardware.RevisionString}");
 
         sensorController = new SensorController(hardware);
+        sensorController.StartUpdating(sensorController.UpdateInterval); // TODO: consider calling after network, time etc are ready?
 
         powerController = new PowerController(hardware);
+        powerController.StartUpdating(powerController.UpdateInterval);   // TODO: consider calling after network, time
+
         powerController.SolarVoltageWarning += OnSolarVoltageWarning;
         powerController.BatteryVoltageWarning += OnBatteryVoltageWarning;
 
@@ -76,6 +79,7 @@ public class MainController
             }
             else
             {
+                Resolver.Log.Info("Network is connected.");
                 notificationController.SetSystemStatus(NotificationController.SystemStatus.NetworkConnected);
                 if (Resolver.MeadowCloudService.ConnectionState == CloudConnectionState.Connecting)
                 {
@@ -96,7 +100,30 @@ public class MainController
 
         _ = SystemPreSleepStateProc();
 
+        Resolver.Log.Info($"Initialize hardware Task.CompletedTask");
+
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Start sensor and power controller updates
+    /// </summary>
+    public void StartUpdating()
+    {
+        Resolver.Log.Info($"Start Updating");
+        sensorController.StartUpdating(sensorController.UpdateInterval);
+        powerController.StartUpdating(powerController.UpdateInterval);
+    }
+
+    /// <summary>
+    /// Stop sensor and power controller updates
+    /// </summary>
+    public void StopUpdating()
+    {
+        Resolver.Log.Info($"Stop Updating");
+        sensorController.StopUpdating();
+        powerController.StopUpdating();
+        sleepSimulationTimer.Change(-1, -1); // stop timer
     }
 
     private void OnPositionReceived(object sender, Peripherals.Sensors.Location.Gnss.GnssPositionInfo e)

--- a/Source/Meadow.Clima/Meadow.Clima.csproj
+++ b/Source/Meadow.Clima/Meadow.Clima.csproj
@@ -30,5 +30,6 @@
     <ProjectReference Include="..\..\..\Meadow.Foundation\Source\Meadow.Foundation.Peripherals\Sensors.Weather.SwitchingAnemometer\Driver\Sensors.Weather.SwitchingAnemometer.csproj" />
     <ProjectReference Include="..\..\..\Meadow.Foundation\Source\Meadow.Foundation.Peripherals\Sensors.Weather.SwitchingRainGauge\Driver\Sensors.Weather.SwitchingRainGauge.csproj" />
     <ProjectReference Include="..\..\..\Meadow.Foundation\Source\Meadow.Foundation.Peripherals\Sensors.Weather.WindVane\Driver\Sensors.Weather.WindVane.csproj" />
+    <ProjectReference Include="..\..\..\Meadow.Logging\Source\Meadow.Logging.LogProviders\Driver\Meadow.Logging.LogProviders.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes issues in develop branch that prevent Meadow connect to wifi and the the cloud. 
Enable OTA updates in yaml and provide event handlers to download and apply the update.  
Register OTA handler for a Restart command with a single parameter Delay that specifies the seconds to wait before restarting Meadow.
Refactor Sensor and Power Controllers to have `StartUpdating(UpdateInterval)` and `StopUpdating()` methods. Call `StopUpdating()` when starting an OTA Update.
Add UdpLogging to remotely monitor the Clima weather station. (In a future version this could be enabled via an OTA Command to avoid unnecessary CPU and network overhead)
Add sanity check to Anemometer to avoid reporting wind speed as `Infinity` which breaks the Sensor data collection.
Change `GetPowerData()` to use `return Task.FromResult(new PowerData{...})` which appears with testing to improve connecting to the WIFI. 
