### PR TITLE
Fix Null Reference bug in CloudController.LogDeviceInfo not defining Dictionary<string, object> before Add()

### DIFF
--- a/Source/Meadow.Clima/Controllers/CloudController.cs
+++ b/Source/Meadow.Clima/Controllers/CloudController.cs
@@ -2,6 +2,7 @@
 using Meadow.Devices.Clima.Constants;
 using Meadow.Devices.Clima.Models;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -47,21 +48,19 @@ public class CloudController
     /// Logs the device information including name and location.
     /// </summary>
     /// <param name="deviceName">The name of the device.</param>
-    /// <param name="latitiude">The latitude of the device location.</param>
+    /// <param name="latitude">The latitude of the device location.</param>
     /// <param name="longitude">The longitude of the device location.</param>
-    public void LogDeviceInfo(string deviceName, double latitiude, double longitude)
+    public void LogDeviceInfo(string deviceName, double latitude, double longitude)
     {
-        var cloudEvent = new CloudEvent
+        Resolver.Log.Info("LogDeviceInfo: Create CloudEvent");
+        CloudEvent cloudEvent = new CloudEvent
         {
             Description = "Clima Position Telemetry",
             Timestamp = DateTime.UtcNow,
             EventId = 109,
+            Measurements = new Dictionary<string, object> { { "device_name", deviceName }, { "lat", latitude }, { "long", longitude } }
         };
-
-        cloudEvent.Measurements.Add("device_name", deviceName);
-        cloudEvent.Measurements.Add("lat", latitiude);
-        cloudEvent.Measurements.Add("long", longitude);
-
+        
         SendEvent(cloudEvent);
     }
 


### PR DESCRIPTION
Clima logs Latitude and Longitude to Meadow Cloud via a call to CloudController.LogDeviceInfo. This method creates a CloudEvent object which is sent to Meadow Cloud.

The initialisation of the Cloud Event needs to allocate and empty Measurements Dictionary<string,object> prior to calling cloudEvent.Measurement.Add(...) method to avoid null reference exception on the undefined Measurements property.

This PR opts to define the Dictionary and add the elements when assigning the other properties and not specifically call Add() method. 

The PR corrects a minor spelling error in the name of the local latitude variable. 