### PR TITLE
Optimise start of LocationController to after Network is connected

### DIFF
--- a/Source/Meadow.Clima/Controllers/LocationController.cs
+++ b/Source/Meadow.Clima/Controllers/LocationController.cs
@@ -1,6 +1,8 @@
 ﻿using Meadow.Devices.Clima.Hardware;
 using Meadow.Peripherals.Sensors.Location.Gnss;
+using Meadow.Units;
 using System;
+using System.Threading;
 
 namespace Meadow.Devices.Clima.Controllers;
 
@@ -21,6 +23,8 @@ public class LocationController
     /// </summary>
     public event EventHandler<GnssPositionInfo>? PositionReceived = null;
 
+    private ManualResetEvent positionReceived = new ManualResetEvent(false);
+
     /// <summary>
     /// Initializes a new instance of the <see cref="LocationController"/> class.
     /// </summary>
@@ -31,9 +35,20 @@ public class LocationController
         {
             this.gnss = gnss;
             this.gnss.GnssDataReceived += OnGnssDataReceived;
-            this.gnss.StartUpdating();
         }
     }
+
+    /// <summary>
+    /// Gets the current geographic position as a <see cref="GeographicCoordinate"/>.
+    /// </summary>
+    /// <value>
+    /// The geographic position, including latitude, longitude, and altitude, if available.
+    /// </value>
+    /// <remarks>
+    /// This property is updated when valid GNSS data is received. It represents the last known position
+    /// and remains unchanged until new valid data is processed.
+    /// </remarks>
+    public GeographicCoordinate? Position { get; private set; } = default;
 
     private void OnGnssDataReceived(object sender, IGnssResult e)
     {
@@ -41,11 +56,45 @@ public class LocationController
         {
             if (pi.IsValid && pi.Position != null)
             {
+                // remember our position
+                Position = pi.Position;
                 // we only need one position fix - weather stations don't move
                 Resolver.Log.InfoIf(LogData, $"GNSS Position: lat: [{pi.Position.Latitude}], long: [{pi.Position.Longitude}]");
+                positionReceived.Set();
                 PositionReceived?.Invoke(this, pi);
-                gnss?.StopUpdating();
+                StopUpdating();
             }
         }
+    }
+
+    /// <summary>
+    /// Starts the GNSS sensor to begin updating location data.
+    /// </summary>
+    /// <remarks>
+    /// This method invokes the <see cref="IGnssSensor.StartUpdating"/> method on the associated GNSS sensor,
+    /// if it is available, to start receiving GNSS data updates.
+    /// </remarks>
+    public void StartUpdating(bool forced = false)
+    {
+        // start updating if forced to find new data or we don;t have current location
+        if (forced || !positionReceived.WaitOne(0))
+        {
+            gnss?.StartUpdating();
+        };
+    }
+
+    /// <summary>
+    /// Stops the GNSS sensor from updating location data.
+    /// </summary>
+    /// <remarks>
+    /// This method halts the GNSS data updates by invoking the <see cref="IGnssSensor.StopUpdating"/> 
+    /// method on the associated GNSS sensor, if it is available.
+    /// </remarks>
+    public void StopUpdating()
+    {
+        // stop listening to data arriving from GNSS
+        gnss?.StopUpdating();
+
+        // TODO: can we tell GNSS sensor to stop calculating GPS location and stop sending data to reduce power consumption?
     }
 }

--- a/Source/Meadow.Clima/MainController.cs
+++ b/Source/Meadow.Clima/MainController.cs
@@ -58,9 +58,9 @@ public class MainController
         powerController.SolarVoltageWarning += OnSolarVoltageWarning;
         powerController.BatteryVoltageWarning += OnBatteryVoltageWarning;
 
-        locationController = new LocationController(hardware);
 
-        locationController.PositionReceived += OnPositionReceived;
+
+
 
         if (networkAdapter == null)
         {
@@ -91,6 +91,9 @@ public class MainController
         Resolver.MeadowCloudService.ConnectionStateChanged += OnMeadowCloudServiceConnectionStateChanged;
         cloudController.LogAppStartup(hardware.RevisionString);
 
+        locationController = new LocationController(hardware);
+        locationController.PositionReceived += OnPositionReceived;
+
         Resolver.Device.PlatformOS.AfterWake += PlatformOS_AfterWake;
 
         if (!lowPowerMode)
@@ -113,6 +116,7 @@ public class MainController
         Resolver.Log.Info($"Start Updating");
         sensorController.StartUpdating(sensorController.UpdateInterval);
         powerController.StartUpdating(powerController.UpdateInterval);
+        locationController.StartUpdating();
     }
 
     /// <summary>
@@ -123,6 +127,7 @@ public class MainController
         Resolver.Log.Info($"Stop Updating");
         sensorController.StopUpdating();
         powerController.StopUpdating();
+        locationController.StopUpdating();
         sleepSimulationTimer.Change(-1, -1); // stop timer
     }
 
@@ -206,7 +211,15 @@ public class MainController
         {
             case CloudConnectionState.Connected:
                 notificationController.SetSystemStatus(NotificationController.SystemStatus.Connected);
+
+                locationController.StartUpdating();
                 break;
+
+            case CloudConnectionState.Disconnected:
+            case CloudConnectionState.Unknown:
+                locationController.StopUpdating();
+                break;
+
             default:
                 notificationController.SetSystemStatus(NotificationController.SystemStatus.ConnectingToCloud);
                 break;


### PR DESCRIPTION
Neo8/GNSS generates a lot of UART data that triggers many interrupts that slow the logon to WIFI and MQTT connect to the Meadow Cloud. 

Starting LocationController after connecting to Meadow Cloud makes overall startup to valid logging of data faster and reduces number of attempts needed to sign on to Meadow Cloud. 

Added Property to store the last measured location.

OTA updates will stop LocationController (if active) which significantly speeds up download of Updates. 