### PR TITLE
Add config option to calibrate WindDirection 

### DIFF
--- a/Source/Clima_Demo/app.config.yaml
+++ b/Source/Clima_Demo/app.config.yaml
@@ -30,3 +30,8 @@ MeadowCloud:
 
     # How often to send metrics to Meadow.Cloud
     HealthMetricsIntervalMinutes: 5
+
+
+# Settings for Clima
+Clima:
+  OffsetToNorth: 0.0


### PR DESCRIPTION
This is one possible way to implement the Feature Request in Issue [Wind direction is uncalibrated](https://github.com/WildernessLabs/Clima/issues/79)

This PR will subtract a configured offset from WindDirection readings before they are averaged. 
A simple method to determine offset is to point the wind vane to north and secure it in place, run Clima_Demo and record the uncalibrated WindDirection. Enter this value in app.config.yaml and the offset will be subtracted from the uncalibrated value, and forcing this direction to be 0 degrees. 

The existing overloaded arithmetic operators automatically limits the value to the range 0 ... 360 degrees. 