### PR TITLE
calculate average wind speed

### DIFF
--- a/Source/Meadow.Clima/Controllers/SensorController.cs
+++ b/Source/Meadow.Clima/Controllers/SensorController.cs
@@ -13,6 +13,7 @@ public class SensorController
 {
     private readonly IClimaHardware clima;
     private readonly CircularBuffer<Azimuth> windVaneBuffer = new CircularBuffer<Azimuth>(12);
+    private readonly CircularBuffer<Speed> windSpeedBuffer = new CircularBuffer<Speed>(12);
     private readonly SensorData latestData;
 
     /// <summary>
@@ -195,17 +196,22 @@ public class SensorController
 
     private void AnemometerUpdated(object sender, IChangeResult<Speed> e)
     {
+        Speed? mean = new Speed(0);
         lock (latestData)
         {
 			// sanity check on windspeed to avoid reporting Infinity
             if (e.New.KilometersPerHour <= 250)
             {
                 latestData.WindSpeed = e.New;
+
+                windSpeedBuffer.Append(e.New);
+                latestData.WindSpeedAverage = mean = windSpeedBuffer.Mean();
             }
         }
 
-        Resolver.Log.InfoIf(LogSensorData, $"Anemometer:      {e.New.MetersPerSecond:0.#} m/s");
-        Resolver.Log.InfoIf(LogSensorData, $"Anemometer:      {e.New.KilometersPerHour:0.#} km/hr");
+        //Resolver.Log.InfoIf(true, $"Anemometer:      {e.New.MetersPerSecond:0.#} m/s");
+        Resolver.Log.InfoIf(LogSensorData, $"Anemometer:      {e.New.KilometersPerHour:0.#} km/hr, Average = {mean?.KilometersPerHour:0.#} km/hr");
+
     }
 
     private void RainGaugeUpdated(object sender, IChangeResult<Length> e)

--- a/Source/Meadow.Clima/Models/SensorData.cs
+++ b/Source/Meadow.Clima/Models/SensorData.cs
@@ -34,6 +34,11 @@ public class SensorData
     public Speed? WindSpeed { get; set; }
 
     /// <summary>
+    /// Gets or sets the average wind speed.
+    /// </summary>
+    public Speed? WindSpeedAverage { get; set; }
+
+    /// <summary>
     /// Gets or sets the wind direction.
     /// </summary>
     public Azimuth? WindDirection { get; set; }
@@ -57,6 +62,7 @@ public class SensorData
         Temperature = null;
         Pressure = null;
         WindSpeed = null;
+        WindSpeedAverage = null;
         WindDirection = null;
         Rain = null;
         Light = null;
@@ -73,6 +79,7 @@ public class SensorData
             Temperature = Temperature,
             Pressure = Pressure,
             WindSpeed = WindSpeed,
+            WindSpeedAverage = WindSpeedAverage,
             WindDirection = WindDirection,
             Rain = Rain,
             Light = Light,
@@ -106,6 +113,10 @@ public class SensorData
         if (WindSpeed != null)
         {
             d.Add(nameof(WindSpeed), WindSpeed.Value.KilometersPerHour);
+        }
+        if (WindSpeedAverage != null)
+        {
+            d.Add(nameof(WindSpeedAverage), WindSpeedAverage.Value.KilometersPerHour);
         }
         if (WindDirection != null)
         {


### PR DESCRIPTION
Implements the feature request [Wind speed should be sampled and averaged](https://github.com/WildernessLabs/Clima/issues/78)

Note this PR requires an extension method to calculate the average (mean) of an IEnumerable<Speed> object. See https://github.com/WildernessLabs/Meadow.Units/pull/76  as a possible example of an extension method that uses Linq to calcuale the average of the collection. 