### PR TITLE
Add humidity, uniform SensorData order and rain units in mm

### DIFF
--- a/Source/Meadow.Clima/Models/SensorData.cs
+++ b/Source/Meadow.Clima/Models/SensorData.cs
@@ -126,7 +126,7 @@ public class SensorData
         }
         if (Rain != null)
         {
-            d.Add(nameof(Rain), Rain.Value.Centimeters);
+            d.Add(nameof(Rain), Rain.Value.Millimeters);
         }
         if (Light != null)
         {

--- a/Source/Meadow.Clima/Models/SensorData.cs
+++ b/Source/Meadow.Clima/Models/SensorData.cs
@@ -58,9 +58,10 @@ public class SensorData
     /// </summary>
     public void Clear()
     {
-        Co2Level = null;
         Temperature = null;
         Pressure = null;
+        Humidity = null;
+        Co2Level = null;
         WindSpeed = null;
         WindSpeedAverage = null;
         WindDirection = null;
@@ -75,9 +76,10 @@ public class SensorData
     {
         return new SensorData
         {
-            Co2Level = Co2Level,
             Temperature = Temperature,
             Pressure = Pressure,
+            Humidity = Humidity,
+            Co2Level = Co2Level,
             WindSpeed = WindSpeed,
             WindSpeedAverage = WindSpeedAverage,
             WindDirection = WindDirection,


### PR DESCRIPTION
Copy() and Clear() methods in SensorData class were missing Humidity.

CHange the order of the properties in Copy() and Clear() to match the order in the rest of the class to make it simpler to check all the values are being defined and copied. 

Also changes reported rain units to mm (were cm)